### PR TITLE
Platform-independent encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,4 +61,7 @@
       <version>1.2.17</version>
     </dependency>
   </dependencies>
+  <properties>
+  	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
 </project>


### PR DESCRIPTION
Forced UTF-8 encoding to remove environment OS's encoding dependency
